### PR TITLE
Use getsize to determine whether file is large

### DIFF
--- a/bed_lookup/_bed_lookup.pyx
+++ b/bed_lookup/_bed_lookup.pyx
@@ -12,6 +12,7 @@ from subprocess import check_output as sub
 from collections import defaultdict
 from libcpp.string cimport string
 from . import _max_len
+from os.path import getsize
 
 
 cdef gopen(infile):
@@ -22,13 +23,7 @@ cdef gopen(infile):
 
 cdef large_file(infile):
     """ Check if file is greater than _max_len """
-    cdef int len = 0
-    with gopen(infile) as f:
-        for line in f:
-            len = len + 1
-            if len > _max_len:
-                return True
-        return False
+    return getsize(infile) > _max_len
 
 
 cdef class Gene(object):


### PR DESCRIPTION
The proposed change is not exactly work-alike, since I'm now asking whether it has more or less than _max_len bytes rather than lines, but since the definition of "big" is arbitrary anyways, I don't think it should be a problem. You might want to change _max_len as well to roughly match the same cutoff as last time, based on some set of "typical" bed files.
